### PR TITLE
use Qt resource system to locate Qml and image files

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -64,7 +64,7 @@ public:
         : QWaylandQuickCompositor(this, 0, DefaultExtensions | SubSurfaceExtension)
         , m_fullscreenSurface(0)
     {
-        setSource(QUrl("main.qml"));
+        setSource(QUrl("qrc:/main.qml"));
         setResizeMode(QQuickView::SizeRootObjectToView);
         setColor(Qt::black);
         winId();

--- a/quantum-shell.pro
+++ b/quantum-shell.pro
@@ -1,20 +1,15 @@
 LIBS += -L ../../lib
 
 QT += quick qml
-QT += quick-private
-
 QT += compositor
-
-#  if you want to compile QtCompositor as part of the application
-#  instead of linking to it, remove the QT += compositor and uncomment
-#  the following line
-#include (../../src/compositor/compositor.pri)
 
 SOURCES += main.cpp
 
-OTHER_FILES = main.qml
+OTHER_FILES = images/*.png \
+	COPYING \
+	README.md
 
-target.path = $$[QT_INSTALL_EXAMPLES]/wayland/qml-compositor
-sources.files = $$OTHER_FILES $$SOURCES $$HEADERS $$RESOURCES $$FORMS qml-compositor.pro
-sources.path = $$[QT_INSTALL_EXAMPLES]/wayland/qml-compositor
-INSTALLS += target sources
+RESOURCES += quantum-shell.qrc
+
+target.path = /usr/bin
+INSTALLS += target

--- a/quantum-shell.qrc
+++ b/quantum-shell.qrc
@@ -1,0 +1,26 @@
+<!DOCTYPE RCC>
+<RCC version="1.0">
+
+<qresource>
+	<file>main.qml</file>
+	<file>ActionCenter.qml</file>
+	<file>Dock.qml</file>
+	<file>DropDown.qml</file>
+	<file>Indicator.qml</file>
+	<file>InteractiveNotification.qml</file>
+	<file>Lockscreen.qml</file>
+	<file>OverlayScreen.qml</file>
+	<file>Panel.qml</file>
+	<file>ProgressListItem.qml</file>
+	<file>Window.qml</file>
+	<file>indicators/ActionCenterIndicator.qml</file>
+	<file>indicators/AppDrawer.qml</file>
+	<file>indicators/DateTimeIndicator.qml</file>
+	<file>indicators/OperationsIndicator.qml</file>
+	<file>indicators/PowerIndicator.qml</file>
+	<file>images/play_music.png</file>
+	<file>images/quantum-os.png</file>
+	<file>images/quantum_wallpaper.png</file>
+</qresource>
+
+</RCC>


### PR DESCRIPTION
quantum-shell binary was being installed in QT_INSTALL_EXAMPLES path
and when installed it could not find any qml file
