### PR TITLE
power indicator: add other devices exposed by upower dbus interface

### DIFF
--- a/qml/indicators/PowerIndicator.qml
+++ b/qml/indicators/PowerIndicator.qml
@@ -16,11 +16,27 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import QtQuick 2.0
+import Material 0.1
 import Material.ListItems 0.1 as ListItem
+import org.nemomobile.dbus 2.0
 import ".."
 
 Indicator {
     id: indicator
+    DBusInterface {
+        id: upower
+
+        bus: DBus.SystemBus
+        service: "org.freedesktop.UPower"
+        iface: "org.freedesktop.UPower"
+        path: "/org/freedesktop/UPower"
+    }
+    Component.onCompleted: {
+        upower.typedCall('EnumerateDevices', [], function (result) {
+                devicesList.model = result
+                //console.log("Devices: "+ result)
+        });
+    }
 
     icon: {
         var level = "full"
@@ -51,7 +67,62 @@ Indicator {
     tooltip: "Power"
 
     dropdown: DropDown {
-
+        implicitHeight: units.dp(200)                       // FIXME please
+        height: devicesList.contentHeight + units.dp(15)
+        ListView {
+            id: devicesList
+            anchors.fill: parent
+            spacing: units.dp(5)
+            delegate: Card {
+                height: col.height + units.dp(30)
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    margins: units.dp(5)
+                }
+                Column {
+                    id: col
+                    spacing: units.dp(15)
+                    anchors.centerIn: parent
+                    Row {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.margins: units.dp(10)
+                        spacing: units.dp(15)
+                        Icon {
+                            property var types: ["unknown",                 // unknown
+                                                 "linepower",               // linepower
+                                                 "battery",                 // battery
+                                                 "ups",                     // ups
+                                                 "hardware/desktop_windows",// monitor
+                                                 "hardware/mouse",          // mouse
+                                                 "hardware/keyboard",       // keyboard
+                                                 "hardware/phone_iphone",   // pda
+                                                 "hardware/phone_android"]  // phone
+                            name: types[deviceInterface.getProperty('Type')]
+                            size: units.dp(18)
+                        }
+                        Label {
+                            text: deviceInterface.getProperty('Vendor')
+                        }
+                        Label {
+                            text: deviceInterface.getProperty('Model')
+                        }
+                    }
+                    ProgressBar {
+                        width: parent.width
+                        height: units.dp(5)
+                        progress: deviceInterface.getProperty('Percentage') / 100
+                    }
+                }
+                DBusInterface {
+                    id: deviceInterface
+                    bus: DBus.SystemBus
+                    service: "org.freedesktop.UPower"
+                    iface: "org.freedesktop.UPower.Device"
+                    path: modelData
+                }
+            }
+        }
     }
 
     BatteryInfo {


### PR DESCRIPTION
this uses https://github.com/nemomobile/nemo-qml-plugin-dbus and UPower dbus interface to list devices connected battery state

![](http://i.imgur.com/yOumuK0.png)