### PR TITLE
Show percentage of battery if timeToEmpty is 0.

### DIFF
--- a/qml/backend/UPower.qml
+++ b/qml/backend/UPower.qml
@@ -75,7 +75,7 @@ UPowerConnection {
 
         if (device.state == UPowerDeviceState.Charging) {
             return "%1 until full".arg(DateUtils.shortDuration(device.timeToFull * 1000, 'm'))
-        } else if (device.state == UPowerDeviceState.Discharging) {
+        } else if (device.state == UPowerDeviceState.Discharging && device.timeToEmpty != 0) {
             return "%1 remaining".arg(DateUtils.shortDuration(device.timeToEmpty * 1000, 'm'))
         } else if (device.state == UPowerDeviceState.FullyCharged) {
             return "Fully Charged"


### PR DESCRIPTION
Percentage will be shown instead of "00:00 remaining" if timeToEmpty is not available.

This is necessary because some devices (mice, keyboards) are not able to retrieve valid information about battery. (Full power, time to empty\full, etc).

Before:
![percentage_before](https://cloud.githubusercontent.com/assets/1764869/6066163/1a7e0df4-ad7c-11e4-8f62-39ff535edf70.png)
After:
![percentage_after](https://cloud.githubusercontent.com/assets/1764869/6066164/1ff0c36c-ad7c-11e4-9ee4-73d46a1d9ff1.png)
