### PR TITLE
Fix the shell not closing when run as a wayland compositor

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,5 +27,7 @@ int main(int argc, char *argv[])
 
     compositor.rootContext()->setContextProperty("compositor", &compositor);
 
+    QObject::connect(compositor.rootContext()->engine(), SIGNAL(quit()), &app, SLOT(quit()));
+
     return app.exec();
 }


### PR DESCRIPTION
This pull request fixes #40.
It simply forwards the signal quit from the QmlEngine to the application