### PR TITLE
HotCorners enhancement and Desktop fix.

### DIFF
--- a/qml/desktop/Desktop.qml
+++ b/qml/desktop/Desktop.qml
@@ -86,9 +86,12 @@ Item {
 
     HotCorners {
         anchors.fill: parent
+        //allow see and use top corners
+        //todo: set margin 0 on desktop.expanded with handling low cursor speed at top corners
+        anchors.topMargin: panel.height
 
         onTopLeftTriggered: {
-            if (desktop.exposed)
+            if (desktop.expanded)
                 shell.state = "default"
             else
                 shell.state = "exposed"

--- a/qml/desktop/HotCorner.qml
+++ b/qml/desktop/HotCorner.qml
@@ -54,6 +54,9 @@ Item {
 
         anchors.centerIn: parent
 
+        border.color: "#ffffff"
+        border.width: 2
+
         height: width
         radius: width/2
         color: Qt.rgba(0,0,0,0.4)


### PR DESCRIPTION
I didn't see a corners on my dark background image so I added a white border that helped me to see them. Also panel blocked the way to top corners. I added a top margin equals to panel height. 
There was mistake(i guess) in name of property in Desktop.qml.