### PR TITLE
Link to AUR was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And run the compositor from an X11 desktop:
  * QtWayland 5.4 with QtCompositor (a CONFIG option is required to enable QtCompositor as it is not compiled by default)
  * The [GSettings QML module](https://launchpad.net/gsettings-qt). This is developed for Ubuntu Touch, but is not Ubuntu-specific
 
-If you're using Arch Linux, you can install the required dependencies using these packages from the [AUR](aur.archlinux.org):
+If you're using Arch Linux, you can install the required dependencies using these packages from the [AUR](http://aur.archlinux.org):
 
  * qt5-base-git
  * qt5-declarative-git


### PR DESCRIPTION
Link was previously not prefixed by "http://"
Page was directed to "https://github.com/papyros/papyros-shell/blob/master/aur.archlinux.org"