### PR TITLE
papyros-session: use exec, use sh instead of bash

### DIFF
--- a/data/papyros-session
+++ b/data/papyros-session
@@ -1,5 +1,5 @@
-#! /bin/bash
+#! /bin/sh
 
 #XCURSOR_SIZE=32 XCURSOR_THEME=Adwaita QT_QPA_EGLFS_DISABLE_INPUT=1 /usr/bin/papyros-shell -platform eglfs -plugin libinput
 
-/usr/bin/papyros-shell -platform eglfs
+exec /usr/bin/papyros-shell -platform eglfs


### PR DESCRIPTION
Nothing bash specific here, no need for it, especially on platforms like debian/ubuntu where they use dash as the default shell.

Also uses exec so the shell process does not hang around after papyros-shell is started.