### PR TITLE
fix linker path resolution of libqtxdg if it has been installed to user-defifned directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines
 find_package(PkgConfig)
 
 find_package(QT5XDG REQUIRED)
-include(${QTXDG_USE_FILE})
+link_directories("${QTXDG_LIBRARY_DIRS}")
+include_directories("${QTXDG_INCLUDE_DIRS}")
 find_package(PAM REQUIRED)
 find_package(GreenIsland 0.5.9 REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -fvisibility-inlines
 find_package(PkgConfig)
 
 find_package(QT5XDG REQUIRED)
+include(${QTXDG_USE_FILE})
 find_package(PAM REQUIRED)
 find_package(GreenIsland 0.5.9 REQUIRED)
 


### PR DESCRIPTION
I found papyros-shell build fails with a error as following if libqtxdg is installed to user-specified directory.

/usr/lib/gcc/x86_64-pc-linux-gnu/4.9.2/../../../../x86_64-pc-linux-gnu/bin/ld: cannot find -lQt5Xdg

We can fix this issue by including qtxdg_use.cmake from libqtxdg in CMakeList.txt

My environment:
Gentoo Linux kernel 4.1-rc5 git-sources
Qt 5.5 latest in git 5.5 branch
qtwayland latest in hawaii project git
GreenIsland latest in git
libqtxdg latest in git
cmake 3.2.2

qt 5.5 is installed to /opt/qt/5.5/gcc
libqtxdg is installed to /opt/qt/5.5/gcc
KDE related libs are installed to /opt/kf5
GreenIsland and payros are installed to /opt/papyros
