### PR TITLE
Fix most QML warnings

### DIFF
--- a/modules/Papyros/Desktop/notifications/notificationserver.h
+++ b/modules/Papyros/Desktop/notifications/notificationserver.h
@@ -35,7 +35,7 @@ class NotificationServer : public QQuickItem
     Q_OBJECT
     Q_DISABLE_COPY(NotificationServer)
 
-    Q_PROPERTY(QObjectListModel *notifications READ notifications)
+    Q_PROPERTY(QObjectListModel *notifications READ notifications NOTIFY notificationsChanged)
 
 public:
     explicit NotificationServer(QQuickItem *parent = new QQuickItem());
@@ -50,6 +50,9 @@ public slots:
     void onNotificationUpdated(uint id, Notification *notification);
     void onNotificationAdded(uint id, Notification *notification);
     void onNotificationRemoved(uint id);
+
+signals:
+    void notificationsChanged();
 
 private:
     NotificationAdaptor *adaptor;

--- a/modules/Papyros/Indicators/BatteryIndicator.qml
+++ b/modules/Papyros/Indicators/BatteryIndicator.qml
@@ -24,10 +24,11 @@ import Material.ListItems 0.1 as ListItem
 Indicator {
     id: indicator
 
+    visible: hardware.batteries.length > 0
     iconName: deviceChargeIcon(hardware.primaryBattery)
     tooltip: deviceSummary(hardware.primaryBattery)
     color: {
-        if (hardware.primaryBattery.chargeState != Battery.Charging) {
+        if (hardware.primaryBattery && hardware.primaryBattery.chargeState != Battery.Charging) {
             if (hardware.primaryBattery.chargePercent < 10) {
                 return Palette.colors.red["500"]
             } else if (hardware.primaryBattery.chargePercent < 15) {
@@ -112,6 +113,9 @@ Indicator {
     }
 
     function deviceChargeIcon(device) {
+        if (!device)
+            return ""
+
         var level = "full"
 
         if (!device)
@@ -142,6 +146,9 @@ Indicator {
     }
 
     function deviceSummary(device) {
+        if (!device)
+            return "";
+
         var percent = device.chargePercent + "%"
 
         print("Battery state", device.chargeState)

--- a/modules/Papyros/Indicators/NetworkIndicator.qml
+++ b/modules/Papyros/Indicators/NetworkIndicator.qml
@@ -29,6 +29,7 @@ Indicator {
     tooltip: networkStatus.activeConnections
 
     property var icons: {
+        "": "device/signal_wifi_0_bar",
         "network-wireless-100-locked": "device/signal_wifi_4_bar",
         "network-wireless-80-locked": "device/signal_wifi_3_bar",
         "network-wireless-60-locked": "device/signal_wifi_2_bar",
@@ -94,6 +95,10 @@ Indicator {
 
     Handler {
         id: handler;
+    }
+
+    AvailableDevices {
+        id: devices
     }
 
     function statusIcon(type, signal) {

--- a/shell/desktop/WindowTooltip.qml
+++ b/shell/desktop/WindowTooltip.qml
@@ -57,7 +57,9 @@ Tooltip {
         Label {
             id: tooltipLabel
             Layout.alignment: Qt.AlignHCenter
-            text: app && app.desktopFile.name !== "" ? app.desktopFile.name : app.appId
+            text: if (!app) { "" }
+                  else if (app.desktopFile.name !== "") { app.desktopFile.name }
+                  else { app.appId }
             color: Theme.dark.textColor
             style: "subheading"
         }


### PR DESCRIPTION
The changes in notificationserver.h fix this warning:

```
QQmlExpression: Expression file:///usr/share/greenisland/shells/io.papyros.shell/notifications/NotificationsView.qml:52:16 depends on non-NOTIFYable properties:
    NotificationServer::notifications
```

The changes in BatteryIndicator.qml fix these warnings (when no batteries are present) and also makes the battery indicator disappear when there are no batteries installed:

```
file:///usr/lib/qt/qml/Papyros/Indicators/BatteryIndicator.qml:30: TypeError: Cannot read property 'chargeState' of null
file:///usr/lib/qt/qml/Papyros/Indicators/BatteryIndicator.qml:145: TypeError: Cannot read property 'chargePercent' of null
```

The changes in NetworkIndicator.qml fix these warnings:

```
file:///usr/lib/qt/qml/Papyros/Indicators/NetworkIndicator.qml:53: ReferenceError: devices is not defined
file:///usr/lib/qt/qml/Papyros/Indicators/NetworkIndicator.qml:28:15: Unable to assign [undefined] to QString
```

And finally the changes in WindowTooltip.qml fix this warning (when no apps have been opened):

```
file:///usr/share/greenisland/shells/io.papyros.shell/desktop/WindowTooltip.qml:60: TypeError: Cannot read property 'appId' of undefined
```

These are all small warnings but I think it's important to fix them early in the project. Also if some change can be done better let me know.
