### PR TITLE
Fix rounding error when getting the sound volume from QML

### DIFF
--- a/modules/Papyros/Desktop/mixer/sound.cpp
+++ b/modules/Papyros/Desktop/mixer/sound.cpp
@@ -91,7 +91,7 @@ int Sound::master() const
 {
     if (m_backend) {
         int vol = m_backend->rawVol();
-        vol = (float)vol * 100.f / (float)m_max;
+        vol = qCeil((double)vol * 100. / (double)m_max);
         return vol;
     }
     return 0;


### PR DESCRIPTION
This fixes a bug appearing with PR #134 : the getter for sound.master was returning an off by one value. It also changes the types used in the calculation from float to double for consistency with the Sound::setMaster() method.
