### PR TITLE
Changing window title to Roboto font

### DIFF
--- a/decorations/main.cpp
+++ b/decorations/main.cpp
@@ -135,6 +135,7 @@ void QWaylandMaterialDecoration::paint(QPaintDevice *device)
         int dy = (top.height()- size.height()) /2;
         QFont font = p.font();
         font.setBold(true);
+        font.setFamily("Roboto");
         p.setFont(font);
         QPoint windowTitlePoint(top.topLeft().x() + dx,
                  top.topLeft().y() + dy);


### PR DESCRIPTION
Uses QFont to set the font-family to Roboto
Fixes #204.

Before:
![papyros-not-roboto](https://cloud.githubusercontent.com/assets/11166947/12072403/cf5fc23a-b0aa-11e5-9bd4-4c5e1772188d.png)

After:
![papyros-roboto](https://cloud.githubusercontent.com/assets/11166947/12072404/cf61141e-b0aa-11e5-8c33-35212af562fc.png)

I can't tell the difference but I'm pretty sure it worked
